### PR TITLE
Form.run calls newtFormRun() and returns ExitStruct

### DIFF
--- a/examples/test_method/Form_ExitStruct.rb
+++ b/examples/test_method/Form_ExitStruct.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require "newt"
+
+begin
+
+  Newt::Screen.new
+
+  b1 = Newt::Button.new(1, 5, "Button1")
+  b2 = Newt::Button.new(1, 9, "Button2")
+
+  b = Newt::Button.new(1, 13, "Exit")
+
+  f = Newt::Form.new
+  f.add_hotkey(?\e.ord)
+  f.add(b1, b2, b)
+
+  rv = f.run()
+
+ensure
+  Newt::Screen.finish
+end
+
+puts rv.inspect
+puts "Button1" if rv == b1
+puts "Button2" if b2 == rv
+puts "Exit" if rv == b
+puts "Escape" if (rv.reason == Newt::EXIT_HOTKEY && rv.key == ?\e.ord)


### PR DESCRIPTION
Sorry for another pull request so soon after the last release. This should be the last one.

This implements Form.run so that it calls newtFormRun(). It returns an ExitStruct class that's implemented in a way that tries to remain backwards compatible with the return value of the previous Form.run.
