### PR TITLE
Checkbox: Fix invalid value when seq is empty string

### DIFF
--- a/examples/test.rb
+++ b/examples/test.rb
@@ -30,7 +30,7 @@ Newt::Screen.refresh
 cs = []
 for i in 0...10
   buf = sprintf("Check %d", i)
-  cs[i] = Newt::Checkbox.new(3, 10 + i, buf, ' ', "")
+  cs[i] = Newt::Checkbox.new(3, 10 + i, buf)
   chklist.add(cs[i])
 end
 

--- a/examples/test_method/Checkbox_new.rb
+++ b/examples/test_method/Checkbox_new.rb
@@ -9,14 +9,30 @@ begin
 
   cb1 = Newt::Checkbox.new(1, 10, "Button1", 'A', nil)
   cb2 = Newt::Checkbox.new(1, 11, "Button2", '', '+')
+  cb3 = Newt::Checkbox.new(1, 12, "Button3", nil, nil)
+  cb4 = Newt::Checkbox.new(1, 13, "Button4", nil, "")
+  b = Newt::Button.new(1, 14, "Exit")
 
-  b = Newt::Button.new(1, 12, "Exit")
+  begin
+    Newt::Checkbox.new(1, 1)
+    raise "ArgumentError not raised"
+  rescue ArgumentError => e
+  end
+
+  begin
+    Newt::Checkbox.new(1, 1, "", nil, nil, nil);
+    raise "ArgumentError not raised"
+  rescue ArgumentError => e
+  end
 
   f = Newt::Form.new
-  f.add(cb1, cb2, b)
+  f.add(cb1, cb2, cb3, cb4, b)
 
   f.run()
 
+  v1, v2, v3, v4 = cb1.get, cb2.get, cb3.get, cb4.get
 ensure
   Newt::Screen.finish
 end
+
+p v1, v2, v3, v4

--- a/examples/test_method/Checkbox_set.rb
+++ b/examples/test_method/Checkbox_set.rb
@@ -1,4 +1,4 @@
-s#!/usr/bin/env ruby
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require "newt"
@@ -8,21 +8,22 @@ begin
   Newt::Screen.new
 
   cb1 = Newt::Checkbox.new(1, 10, "Button1", '', nil)
-  cb2 = Newt::Checkbox.new(1, 11, "Button2", '', nil)
-  cb1.set('***')
-  #cb1.set('*')
-  #cb1.set('')
-
-  b = Newt::Button.new(1, 12, "Exit")
+  cb2 = Newt::Checkbox.new(1, 11, "Button2", nil, nil)
+  cb3 = Newt::Checkbox.new(1, 12, "Button3", 'A', nil)
+  cb4 = Newt::Checkbox.new(1, 13, "Button4", nil, "XO")
+  cb5 = Newt::Checkbox.new(1, 14, "Button5", nil, "XO")
+  cb6 = Newt::Checkbox.new(1, 15, "Button6", '', nil)
+  cb1.set('***'); cb2.set('**'); cb3.set('*'); cb4.set('O'); cb5.set('A')
+  b = Newt::Button.new(1, 16, "Exit")
 
   f = Newt::Form.new
-  f.add(cb1, cb2, b)
+  f.add(cb1, cb2, cb3, cb4, cb5, cb6, b)
 
   f.run()
 
-  v1, v2 = cb1.get, cb2.get
+  v1, v2, v3, v4, v5, v6 = cb1.get, cb2.get, cb3.get, cb4.get, cb5.get, cb6.get
 ensure
   Newt::Screen.finish
 end
 
-p v1, v2
+p v1, v2, v3, v4, v5, v6

--- a/ext/ruby_newt/ruby_newt.c
+++ b/ext/ruby_newt/ruby_newt.c
@@ -679,18 +679,28 @@ static VALUE rb_ext_Button_new(VALUE self, VALUE left, VALUE top, VALUE text)
   return Data_Wrap_Struct(self, 0, 0, co);
 }
 
-static VALUE rb_ext_Checkbox_new(VALUE self, VALUE left, VALUE top, VALUE text,
-    VALUE defValue, VALUE seq)
+static VALUE rb_ext_Checkbox_new(int argc, VALUE *argv, VALUE self)
 {
   newtComponent co;
+  const char *text;
+  int left, top;
+  const char *seq = NULL;
+  char defValue = 0;
 
-  if (NIL_P(seq)) {
-    co = newtCheckbox(NUM2INT(left), NUM2INT(top), StringValuePtr(text),
-        StringValuePtr(defValue)[0], NULL, NULL);
-  } else {
-    co = newtCheckbox(NUM2INT(left), NUM2INT(top), StringValuePtr(text),
-        StringValuePtr(defValue)[0], StringValuePtr(seq), NULL);
-  }
+  if (argc < 3 || argc > 5)
+    rb_raise(rb_eArgError, "wrong number of arguments (given %d, expected 3..5)", argc);
+
+  left = NUM2INT(argv[0]);
+  top = NUM2INT(argv[1]);
+  text = StringValuePtr(argv[2]);
+
+  if (argc > 3 && !NIL_P(argv[3]))
+    defValue = StringValuePtr(argv[3])[0];
+
+  if (argc == 5 && !NIL_P(argv[4]) && RSTRING_LEN(argv[4]) > 0)
+    seq = StringValuePtr(argv[4]);
+
+  co = newtCheckbox(left, top, text, defValue, seq, NULL);
   return Data_Wrap_Struct(self, 0, 0, co);
 }
 
@@ -1387,7 +1397,7 @@ void Init_ruby_newt(){
   rb_define_singleton_method(cButton, "new", rb_ext_Button_new, 3);
 
   cCheckbox = rb_define_class_under(mNewt, "Checkbox", cWidget);
-  rb_define_singleton_method(cCheckbox, "new", rb_ext_Checkbox_new, 5);
+  rb_define_singleton_method(cCheckbox, "new", rb_ext_Checkbox_new, -1);
   rb_define_method(cCheckbox, "get", rb_ext_Checkbox_GetValue, 0);
   rb_define_method(cCheckbox, "set", rb_ext_Checkbox_SetValue, 1);
   rb_define_method(cCheckbox, "set_flags", rb_ext_Checkbox_SetFlags, -2);


### PR DESCRIPTION
When an empty string is passed as the sequence value to Checkbox.new(),
newt attempts to assign an invalid value to the Checkbox when the
Checkbox is checked. Use newt's default values if an empty string is
passed as seq. Also, allow omitting the defValue and seq parameters.