### PR TITLE
Fix s-lang's pkg-config package name

### DIFF
--- a/ext/ruby_newt/extconf.rb
+++ b/ext/ruby_newt/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 
-pkg_config('s-lang')
+pkg_config('slang')
 pkg_config(RUBY_PLATFORM.include?('darwin') ? 'libnewt' : 'newt')
 
 append_cflags(ENV['CFLAGS'])


### PR DESCRIPTION
Although it compiles either way, this is the exact name in `pkg-config`.